### PR TITLE
Making links blue in line with recent UXR findings

### DIFF
--- a/application/templates/considerations.html
+++ b/application/templates/considerations.html
@@ -25,7 +25,7 @@
     <h1 class="govuk-heading-xl">Planning considerations backlog</h1>
 
     <p class="govuk-body-l">
-      This is the list of planning considerations on the {{ site_settings.team_name }}'s backlog.
+      This is the list of planning considerations on the backlog.
     </p>
 
     <details class="govuk-details">

--- a/application/templates/index.html
+++ b/application/templates/index.html
@@ -9,7 +9,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
         <h1 class="govuk-heading-xl app-masthead__title govuk-!-margin-bottom-2">
-          Designing planning and housing data for planning.data.gov.uk
+          Designing planning and housing data that works for everyone
         </h1>
         <p class="govuk-body-l govuk-!-margin-bottom-0 app-masthead__sub-title">
           Help identify and design data for <a href="https://www.planning.data.gov.uk/" class="govuk-link govuk-link--inverse">planning.data.gov.uk</a> 
@@ -35,7 +35,7 @@
                 href="{{ url_for('planning_consideration.considerations') }}">
                 <div class="app-content-list__link-text">List of planning considerations</div>
                 <div class="app-content-list__description app-content-list__link-description">
-                  A list of all the planning considerations that are candidates for planning.data.gov.uk
+                  A list of all the planning considerations on the backlog for planning.data.gov.uk
                 </div>
               </a>
             </h3>
@@ -48,7 +48,7 @@
                 class="app-content-list__link"
                 data-track-count="cardLink"
                 href="{{ url_for('main.what_we_are_working_on') }}">
-                <div class="app-content-list__link-text">Our priorities</div>
+                <div class="app-content-list__link-text">What’s being worked on now and next</div>
                 <div class="app-content-list__description app-content-list__link-description">
                   An overview of the planning considerations being worked on now and in the future
                 </div>

--- a/application/templates/layouts/base.html
+++ b/application/templates/layouts/base.html
@@ -54,7 +54,7 @@
         <ul id="navigation" class="govuk-header__navigation-list">
           <li class="govuk-header__navigation-item">
             <a class="govuk-header__link" href="{{ url_for('planning_consideration.considerations') }}">
-              All planning considerations
+              List of planning considerations
             </a>
           </li>
           <li class="govuk-header__navigation-item">

--- a/application/templates/what-we-are-working-on.html
+++ b/application/templates/what-we-are-working-on.html
@@ -3,7 +3,7 @@
 {% macro considerationListItem(consideration) %}
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key">
-    <a href="{{ url_for('planning_consideration.consideration', slug=consideration.slug)}}" class="govuk-link govuk-link--text-colour">{{ consideration.name }}</a>
+    <a href="{{ url_for('planning_consideration.consideration', slug=consideration.slug)}}" class="govuk-link">{{ consideration.name }}</a>
     <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0">
       <span class="govuk-tag govuk-tag--blue">{{ consideration.stage.value }}</span>
       {%- if consideration.blocked_reason %}


### PR DESCRIPTION
I only made this change on the 'what are we working on' page. Users in research sessions didn't realise that they were clickable links when the text was in black.