### PR TITLE
Allow insecure urls for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,10 @@ Manage planning considerations through standards process
 
 ### To test authentication in local development
 
-Set the following in DevelopmentConfig
-
-    AUTHENTICATION_ON = True
-
 The below is needed for local development and must not be committed to github. Therefore
 add to a file called ```.env``` which is gitignored.
 
+    AUTHENTICATION_ON=true
     GITHUB_CLIENT_ID=[client id]
     GITHUB_CLIENT_SECRET=[secret]
 

--- a/application/blueprints/auth/views.py
+++ b/application/blueprints/auth/views.py
@@ -14,7 +14,11 @@ def login():
     session["next"] = _make_next_url_safe(request.args.get("next", "/"))
     if not current_app.config.get("AUTHENTICATION_ON", False):
         return redirect(session["next"])
-    auth_url = url_for("auth.authorize", _external=True, _scheme="https")
+    auth_url = url_for(
+        "auth.authorize",
+        _external=True,
+        _scheme="http" if current_app.config["ENV"] == "development" else "https",
+    )
     return oauth.github.authorize_redirect(auth_url)
 
 

--- a/application/factory.py
+++ b/application/factory.py
@@ -67,7 +67,9 @@ def register_context_processors(app):
                 "team_name": "Data Design team",
             },
             "github_discussion_base_url": "https://github.com/digital-land/data-standards-backlog/discussions",
-            "platform_url": os.getenv("PLATFORM_URL", "https://www.planning.data.gov.uk"),
+            "platform_url": os.getenv(
+                "PLATFORM_URL", "https://www.planning.data.gov.uk"
+            ),
         }
 
     app.context_processor(global_variables_context_processor)
@@ -137,6 +139,7 @@ def register_extensions(app):
             authorize_params=None,
             api_base_url="https://api.github.com/",
             client_kwargs={"scope": "user:email read:org"},
+            allow_insecure_http=app.config["ENV"] == "development",
         )
 
     if os.environ.get("SENTRY_DSN") is not None:

--- a/application/templates/layouts/base.html
+++ b/application/templates/layouts/base.html
@@ -65,7 +65,7 @@
       'active': request.path == url_for('main.page', page='data-design-process')
     },
     {
-      'href': url_for('auth.logout') if not config.AUTHENTICATION_ON or session["user"] else url_for('auth.login', next=request.path, _external=True, _scheme='https'),
+      'href': url_for('auth.logout') if not config.AUTHENTICATION_ON or session["user"] else url_for('auth.login', next=request.path, _external=True, _scheme='http' if config.ENV == 'development' else 'https'),
       'text': "Sign out" if not config.AUTHENTICATION_ON or session["user"] else "Sign in"
     }
   ]


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Allow insecure URLs for local development. Without this change, we cannot test the authentication locally as the URLs generated are `https://localhost:5050` and not `http://localhost:5050`.