### PR TITLE
added considerations that had a planning permissions tag to the page

### DIFF
--- a/application/blueprints/project/views.py
+++ b/application/blueprints/project/views.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, render_template
+from application.models import Consideration
 
 project = Blueprint("project", __name__)
 
@@ -10,8 +11,14 @@ def index():
 
 @project.route("/project/planning-applications")
 def planning_applications():
-    return render_template("advisory-group.html")
-
+    considerations = sorted(
+        Consideration.query.all(),
+        key=lambda c: c.name,
+    )
+    return render_template(
+        "advisory-group.html",
+        considerations=considerations,
+    )
 
 @project.route("/project/planning-applications/members")
 def advisory_group_members():

--- a/application/templates/advisory-group.html
+++ b/application/templates/advisory-group.html
@@ -40,9 +40,9 @@
       'html': notificationBannerHtml,
     }) #}
 
-    <p class="govuk-body-l">MHCLG Digital Planning are developing a set of open, reusable data specifications to underpin planning applications. These will make sure the <a href="https://www.gov.uk/government/publications/planning-application-forms-templates-for-local-planning-authorities" class="govuk-link">current templates</a> are underpinned by data.</p>
+    <p class="govuk-body-l">MHCLG Digital Planning are developing a set of open, reusable data specifications to help standardise the information submitted when a planning application is made.</p>
 
-    <p class="govuk-body-l">The specifications will define the structure and format of data that is required when submitting a planning application based on the national legislation in place.</p>
+    <p class="govuk-body-l">These specifications will ensure that the data is consistent and meets requirements set out in national legislation.</p>
 
     <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 

--- a/application/templates/advisory-group.html
+++ b/application/templates/advisory-group.html
@@ -44,6 +44,35 @@
 
     <p class="govuk-body-l">The specifications will define the structure and format of data that is required when submitting a planning application based on the national legislation in place.</p>
 
+    <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+    <h2 class="govuk-heading-m" id="Related considerations">Related considerations</h2>
+
+    <p class="govuk-body">We have identified the following considerations as being related to planning applications.</p>
+
+    <dl class="govuk-summary-list">
+      {% for consideration in considerations %}
+        {% set tag_names = consideration.tags | map(attribute='name') | map('lower') | list %}
+        {% if 'planning permission' in tag_names%}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+        <a href="{{ url_for('planning_consideration.consideration', slug=consideration.slug) }}" class="govuk-link govuk-link--text-colour">{{ consideration.name }}</a>
+          </dt>
+        
+          <dd class="govuk-summary-list__actions govuk-!-text-align-left">
+            <p class="govuk-body govuk-!-margin-bottom-0">
+            {%- if consideration.github_discussion_number is not none %}
+              {% set discussion_link = github_discussion_base_url + "/" + consideration.github_discussion_number|string %}
+              <a href="{{ discussion_link }}" class="govuk-link">Github discussion</a>
+            {% endif -%}
+            </p>
+          </dd>
+        </div>
+        {% endif %}
+      {% endfor %}
+    </dl>    
+
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--invisible">
 
     <h2 class="govuk-heading-m" id="Timeline">Events timeline</h2>
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

On the planning applications project pages, it now shows any considerations tagged 'planning permission' as a related consideration before going into the events timeline

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link
- Related Issue https://github.com/digital-land/data-design/issues/50_

## QA Instructions, Screenshots, Recordings
I've tested this locally using the local plans tag (my database is out of date so doesnt show current tags). This is how it would display.

<img width="867" height="696" alt="Screenshot 2025-09-23 at 15 11 07" src="https://github.com/user-attachments/assets/e9736bc6-e8af-4b42-8dcd-0a33c5574c5c" />

These are [the considerations](https://design.planning.data.gov.uk/planning-consideration/?tag=planning+permission) that would show as related


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [x] I need help with writing tests



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advisory group page now includes a “Related considerations” section before the Events timeline, showing items relevant to planning permission.
  * Each item links to its detail page and, where available, includes a GitHub discussion link.
  * Considerations are presented in a predictable order and dynamically reflect current data.

* **Content**
  * Introductory copy updated to explain data specifications and alignment with national legislation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->